### PR TITLE
Abstract away the weight data source

### DIFF
--- a/scripts/dataframe_creator.py
+++ b/scripts/dataframe_creator.py
@@ -1,0 +1,59 @@
+import json
+from abc import abstractmethod
+from typing import Protocol
+
+import pandas as pd
+
+from scripts.columns import DATE_COLUMN, WEIGHT_IN_GRAMS_COLUMN
+from scripts.files import RAW_DATA_FILE
+
+
+class WeightDataFrameCreator(Protocol):
+    # pylint: disable=too-few-public-methods
+    @abstractmethod
+    def get_dataframe(self) -> pd.DataFrame:
+        """
+        Return a DataFrame with daily weight measurements.
+
+        Returns:
+        pd.DataFrame
+            A DataFrame containing daily weight data where:
+            - DATE_COLUMN is used as the datetime index
+            - WEIGHT_IN_GRAMS_COLUMN contains integer weight values in grams
+            - Data includes exactly one row per day with no missing values
+        """
+
+
+class GarminWeightDataFrameCreator(WeightDataFrameCreator):
+    # pylint: disable=too-few-public-methods
+    """
+    Takes the weight of the first weight measurement of each day and rounds it to the nearest integer.
+    Loads the raw data from a local JSON file.
+
+    This function expects a dictionary containing a "dailyWeightSummaries" key, where each item includes:
+     - "summaryDate": A string representing the date.
+     - "allWeightMetrics": A list of dictionaries with a "weight" key, specifying weight in grams.
+    """
+
+    def get_dataframe(self) -> pd.DataFrame:
+        data = self._load_data()
+        daily_weights = [
+            (d["summaryDate"], round(d["allWeightMetrics"][0]["weight"]))
+            for d in data["dailyWeightSummaries"]
+        ]
+        df = pd.DataFrame(daily_weights, columns=[DATE_COLUMN, WEIGHT_IN_GRAMS_COLUMN])
+
+        # fill in missing dates
+        df[DATE_COLUMN] = pd.to_datetime(df[DATE_COLUMN])
+        df.set_index(DATE_COLUMN, inplace=True)
+        df = df.resample("D").asfreq()
+
+        df[WEIGHT_IN_GRAMS_COLUMN] = (
+            df[WEIGHT_IN_GRAMS_COLUMN].interpolate(method="linear").round().astype(int)
+        )
+
+        return df
+
+    def _load_data(self) -> dict:
+        with open(RAW_DATA_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)

--- a/scripts/process.py
+++ b/scripts/process.py
@@ -1,5 +1,3 @@
-import json
-
 import pandas as pd
 
 from scripts.columns import (
@@ -8,7 +6,7 @@ from scripts.columns import (
     WEIGHT_IN_GRAMS_14D_COLUMN,
     WEIGHT_IN_GRAMS_COLUMN,
 )
-from scripts.files import RAW_DATA_FILE
+from scripts.dataframe_creator import GarminWeightDataFrameCreator
 from scripts.plot import plot_figures
 from scripts.predictions import DailyWeightForecaster
 from scripts.process_weight_data import (
@@ -56,10 +54,9 @@ def process_daily_data(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def process(send_plots: bool = False) -> None:
-    with open(RAW_DATA_FILE, "r", encoding="utf-8") as f:
-        data = json.load(f)
-
-    df_weight_data = process_weight_data(data)
+    df_weight_data = process_weight_data(
+        weight_dataframe_creator=GarminWeightDataFrameCreator()
+    )
     df_daily_data = process_daily_data(df_weight_data.copy())
     df_weekly_data = process_weekly_data(df_weight_data.copy())
 

--- a/tests/test_process_weight_data.py
+++ b/tests/test_process_weight_data.py
@@ -87,7 +87,8 @@ class TestAddMovingAverageAndChange(unittest.TestCase):
 
 
 class TestProcessWeightData(unittest.TestCase):
-    def test_process_weight_data(self):
+    @patch("scripts.dataframe_creator.GarminWeightDataFrameCreator._load_data")
+    def test_process_weight_data(self, mock_load_data):
         data = {
             "dailyWeightSummaries": [
                 {"summaryDate": "2023-01-01", "allWeightMetrics": [{"weight": 70}]},
@@ -122,6 +123,7 @@ class TestProcessWeightData(unittest.TestCase):
                 {"summaryDate": "2023-01-30", "allWeightMetrics": [{"weight": 99}]},
             ]
         }
+        mock_load_data.return_value = data
 
         # data only becomes meaningful after 14 days
         expected_data = {
@@ -134,7 +136,9 @@ class TestProcessWeightData(unittest.TestCase):
             expected_data, index=pd.to_datetime(["2023-01-22", "2023-01-29"])
         ).astype("int64")
 
-        result_df = process_weight_data(data)
+        result_df = process_weight_data(
+            weight_dataframe_creator=GarminWeightDataFrameCreator()
+        )
         result_df = filter_df_to_weekly_changes(result_df)
         assert_frame_equal(result_df, expected_df, check_freq=False, check_names=False)
 


### PR DESCRIPTION
This pull request introduces a new class structure to handle the creation of weight data frames and refactors the existing code to use this new structure. The primary goal is to improve code modularity and readability. The most important changes include the addition of the `WeightDataFrameCreator` protocol and the `GarminWeightDataFrameCreator` class, as well as the refactoring of related functions to utilize these new classes.

### New class structure for data frame creation:

* [`scripts/dataframe_creator.py`](diffhunk://#diff-0ed70f3e4c42f7ef5f958c995e0b4d173357bf88132119ace70e35b3e4e38107R1-R59): Introduced the `WeightDataFrameCreator` protocol and the `GarminWeightDataFrameCreator` class to encapsulate the logic for creating weight data frames. The `GarminWeightDataFrameCreator` class loads raw data from a local JSON file and processes it to generate a data frame with daily weight measurements.

### Refactoring to use new class structure:

* [`scripts/process.py`](diffhunk://#diff-d63cebf1f62f5283d048493c6ca292694395cbf5cf6503df911302a60dc9441bL1-L2): Refactored the `process` function to use the `GarminWeightDataFrameCreator` class instead of directly loading raw data. Removed the import of `json` and `RAW_DATA_FILE` as they are no longer needed. [[1]](diffhunk://#diff-d63cebf1f62f5283d048493c6ca292694395cbf5cf6503df911302a60dc9441bL1-L2) [[2]](diffhunk://#diff-d63cebf1f62f5283d048493c6ca292694395cbf5cf6503df911302a60dc9441bL11-R9) [[3]](diffhunk://#diff-d63cebf1f62f5283d048493c6ca292694395cbf5cf6503df911302a60dc9441bL59-R59)
* [`scripts/process_weight_data.py`](diffhunk://#diff-a8a8cc8e0a343b6e3fb010fa0ec47bce31b470f275e6e47a303794b3e396efb1L6-R36): Refactored the `process_weight_data` function to accept a `WeightDataFrameCreator` instance, which is used to obtain the weight data frame. Removed the old `create_weight_data_frame` and `process_weight_data` functions that directly processed raw data. [[1]](diffhunk://#diff-a8a8cc8e0a343b6e3fb010fa0ec47bce31b470f275e6e47a303794b3e396efb1L6-R36) [[2]](diffhunk://#diff-a8a8cc8e0a343b6e3fb010fa0ec47bce31b470f275e6e47a303794b3e396efb1L42-L88)