### PR TITLE
Use ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,15 +5,12 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
--   repo: https://github.com/psf/black
-    rev: 22.10.0
-    hooks:
-    -   id: black
--   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        name: isort (python)
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.11.6
+  hooks:
+    - id: ruff
+      args: [ --fix ]
+    - id: ruff-format
 -   repo: local
     hooks:
       - id: pylint

--- a/scripts/plot.py
+++ b/scripts/plot.py
@@ -37,7 +37,6 @@ def plot_weight(
     df: pd.DataFrame,
     targets_df: pd.DataFrame,
 ) -> None:
-
     is_gaining_weight = (df["target_weight_change_14d"] > 0).any()
     va_position_14d = "top" if is_gaining_weight else "bottom"
     va_position_14d_offset = -100 if is_gaining_weight else 100


### PR DESCRIPTION
This pull request introduces updates to the pre-commit configuration and removes unused code in a plotting script. The most significant changes involve replacing code formatting tools in `.pre-commit-config.yaml` and cleaning up unnecessary blank lines in `scripts/plot.py`.

### Pre-commit configuration updates:
* Replaced `black` and `isort` with `ruff` and `ruff-format` in `.pre-commit-config.yaml`, which simplifies the configuration by consolidating linting and formatting tasks into a single tool.
